### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ You can use it to convert learner corpora from one format to the other (e.g., xm
 ## Install gec-preprocess
 
 ```bash
-pip install https://github.com/NTHU-NLPLAB/gec-preprocess/archive/master.zip
+pip install https://github.com/NTHU-NLPLAB/gec-preprocess/archive/main.zip
 ```
 
 ## Usage


### PR DESCRIPTION
Fix a broken link in the installation section:

```sh
$ pip install https://github.com/NTHU-NLPLAB/gec-preprocess/archive/master.zip
Collecting https://github.com/NTHU-NLPLAB/gec-preprocess/archive/master.zip
  ERROR: HTTP error 404 while getting https://github.com/NTHU-NLPLAB/gec-preprocess/archive/master.zip
ERROR: Could not install requirement https://github.com/NTHU-NLPLAB/gec-preprocess/archive/master.zip because of HTTP error 404 Client Error: Not Found for url: https://codeload.github.com/NTHU-NLPLAB/gec-preprocess/zip/master for URL https://github.com/NTHU-NLPLAB/gec-preprocess/archive/master.zip
```